### PR TITLE
Display argument list in a better way

### DIFF
--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\FlattenException;
 
 /**
  * Notifier
@@ -211,6 +212,10 @@ class Notifier
     public function createMailAndSend($exception, $request, $context = null)
     {
 
+        if (!$exception instanceof FlattenException) {
+            $exception = FlattenException::create($exception);
+        }
+        
         $body = $this->templating->render('ElaoErrorNotifierBundle::mail.html.twig', array(
             'exception'       => $exception,
             'exception_class' => get_class($exception),

--- a/Resources/views/mail.html.twig
+++ b/Resources/views/mail.html.twig
@@ -340,38 +340,39 @@
                         <td>
                             <div class="block">
                                 <h4>Stack Trace</h4>
-
-                                {# see TwigBundle:Exception:traces.html.twig #}
-                                <ol class="traces list_exception" id="traces">
-                                    {% for i, trace in exception.trace %}
-                                        {# see TwigBundle:Exception:trace.html.twig #}
-                                        <li>
-                                        {% if trace.class is defined %}
-                                            at
-                                            <strong>
-                                                <abbr title="{{ trace.class }}">{{ trace.class }}</abbr>
-                                                {{ trace.type ~ trace.function }}
-                                            </strong>
-                                            {% if trace.args is defined %}
-                                                {% if trace.args is iterable %}
-                                                    {{ trace.args|json_encode }}
-                                                {% else %}
-                                                    ({{ trace.args }})
+                                {% for position, e in exception.toarray %}
+                                    {# see TwigBundle:Exception:traces.html.twig #}
+                                    <ol class="traces list_exception" id="traces">
+                                        {% for i, trace in exception.trace %}
+                                            {# see TwigBundle:Exception:trace.html.twig #}
+                                            <li>
+                                            {% if trace.class is defined %}
+                                                at
+                                                <strong>
+                                                    <abbr title="{{ trace.class }}">{{ trace.class }}</abbr>
+                                                    {{ trace.type ~ trace.function }}
+                                                </strong>
+                                                {% if trace.args is defined %}
+                                                    {% if trace.args is iterable %}
+                                                        {{ trace.args|format_args }}
+                                                    {% else %}
+                                                        ({{ trace.args }})
+                                                    {% endif %}
                                                 {% endif %}
+                                            {% else %}
+                                                {{ trace.function }}()
                                             {% endif %}
-                                        {% else %}
-                                            {{ trace.function }}()
-                                        {% endif %}
-                                        {% if trace.file is defined and trace.file and trace.line is defined and trace.line %}
-                                            {{ trace.function ? '<br />' : '' }}
-                                            in {{ trace.file|format_file(trace.line) }}&nbsp;
-                                            <div id="trace_{{ 0 ~ '_' ~ i }}" class="trace">
-                                                {{ trace.file|file_excerpt(trace.line) }}
-                                            </div>
-                                        {% endif %}
-                                        </li>
-                                    {% endfor %}
-                                </ol>
+                                            {% if trace.file is defined and trace.file and trace.line is defined and trace.line %}
+                                                {{ trace.function ? '<br />' : '' }}
+                                                in {{ trace.file|format_file(trace.line) }}&nbsp;
+                                                <div id="trace_{{ 0 ~ '_' ~ i }}" class="trace">
+                                                    {{ trace.file|file_excerpt(trace.line) }}
+                                                </div>
+                                            {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ol>
+                                {% endfor %}
                             </div>
                         </td>
                     </tr>

--- a/Twig/DumpyTwigFilter.php
+++ b/Twig/DumpyTwigFilter.php
@@ -45,7 +45,6 @@ class DumpyTwigFilter extends \Twig_Extension
         return array(
             'pre'   => new \Twig_Filter_Method($this, 'pre', $optionsForRaw),
             'dump'  => new \Twig_Filter_Method($this, 'preDump', $optionsForRaw),
-            'ydump' => new \Twig_Filter_Method($this, 'preYamlDump', $optionsForRaw),
             'dumpy' => new \Twig_Filter_Method($this, 'preYamlDump', $optionsForRaw),
         );
     }
@@ -173,6 +172,35 @@ class DumpyTwigFilter extends \Twig_Extension
                 }
 
                 return $data;
+            }
+        }
+        
+        if(is_string($value))
+        {
+            $value = '(string) '.$value;
+        }
+        
+        if(is_int($value))
+        {
+            $value = '(int) '.$value;
+        }
+        
+        if(is_float($value))
+        {
+            $value = '(float) '.$value;
+        }
+        
+        if(is_null($value))
+        {
+            $value = 'null';
+        }
+        
+        if(is_bool($value))
+        {
+            if($value) {
+                $value = '(bool) true';
+            }else {
+                $value = '(bool) false';
             }
         }
 


### PR DESCRIPTION
The mail.html.twig file tries to json_encode any arguments which are passed to the methods in the stack trace, but if these arguments have any private properties (like doctrine objects) it will cause a 'recursion detected' warning. See this blog post for more info - http://blog.jezmckean.com/php-bug-json_encode-misleading-warning-on-object-with-private-properties/

I've changed the mail twig template so that it's more like Symfony's own formatter and calls format_args instead of json_encode, which fixes the problem.
