### PR TITLE
Added ignoredPhpErrors param and fixed missing end() in config after prototype() on arrayNode

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,12 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('ignoredClasses')
                     ->prototype('scalar')
+                    ->end()
+                    ->treatNullLike(array())
+                ->end()
+                ->arrayNode('ignoredPhpErrors')
+                    ->prototype('scalar')
+                    ->end()
                     ->treatNullLike(array())
                 ->end()
             ->end();


### PR DESCRIPTION
ignoredPhpErrors could be useful if someone prefer to ignore some error, exactly as for ignoredClasses about exceptions.
E.g. someone on a shared hosting prefer to ignore some notice / warning but not ALL of them.

Instead, about prototype(), it should be ended like any other node!
source: http://symfony.com/doc/current/components/config/definition.html#array-nodes