### PR TITLE
Removing use of array_splice as it typecasts to (array)

### DIFF
--- a/Twig/DumpyTwigFilter.php
+++ b/Twig/DumpyTwigFilter.php
@@ -208,7 +208,6 @@ class DumpyTwigFilter extends \Twig_Extension
     public function sanitizeIterateable ($value, $maxRecursionDepth = self::MAX_DEPTH, $recursionDepth = 0)
     {
         if ($recursionDepth < $maxRecursionDepth) {
-
             $r = array ();
             $arrayCount = count($value);
             $count = 0;

--- a/Twig/DumpyTwigFilter.php
+++ b/Twig/DumpyTwigFilter.php
@@ -208,19 +208,18 @@ class DumpyTwigFilter extends \Twig_Extension
     public function sanitizeIterateable ($value, $maxRecursionDepth = self::MAX_DEPTH, $recursionDepth = 0)
     {
         if ($recursionDepth < $maxRecursionDepth) {
+
             $r = array ();
             $arrayCount = count($value);
-
-            if($arrayCount > 20) {
-                $value = array_splice($value, 0, 20);
-            }
+            $count = 0;
 
             foreach ($value as $k => $v) {
                 $r[$k] = $this->sanitize($v, $maxRecursionDepth, $recursionDepth + 1);
-            }
-
-            if($arrayCount > 20) {
-                $r[] = sprintf('... and %s more ...', ($arrayCount - 20));
+                $count++;
+                if($count >= 20) {
+                    $r[] = sprintf('... and %s more ...', ($arrayCount - $count));
+                    break;
+                }
             }
             
             return $r;


### PR DESCRIPTION
I've been getting some issues with a previous PR I did. The object dump in the email takes an iterable object and runs array_splice on it to limit it to the first 20 items. Unfortunately array_splice has some unintended side effects like ruining numerical keys and type casting the iterable to an array, which might not be the intended behaviour. I've just replaced it with a simple count.