### PR TITLE
#47 Ignore IPs for http exceptions

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -71,6 +71,11 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->treatNullLike(array())
                 ->end()
+                ->arrayNode('ignoredIPs')
+                    ->prototype('scalar')
+                    ->end()
+                    ->treatNullLike(array())
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -96,7 +96,11 @@ class Notifier
         $exception = $event->getException();
 
         if ($exception instanceof HttpException) {
-            if (!in_array($event->getRequest()->getClientIp(), $this->ignoredIPs) && (500 === $exception->getStatusCode() || (404 === $exception->getStatusCode() && true === $this->handle404) || (in_array($exception->getStatusCode(), $this->handleHTTPcodes)))) {
+            if (in_array($event->getRequest()->getClientIp(), $this->ignoredIPs)) {
+                return;
+            }
+
+            if (500 === $exception->getStatusCode() || (404 === $exception->getStatusCode() && true === $this->handle404) || (in_array($exception->getStatusCode(), $this->handleHTTPcodes))) {
                 $this->createMailAndSend($exception, $event->getRequest());
             }
         } else {

--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -46,6 +46,7 @@ class Notifier
     private $reportErrors   = false;
     private $reportSilent   = false;
     private $repeatTimeout  = false;
+    private $ignoredIPs;
     private $command;
     private $commandInput;
 
@@ -74,6 +75,7 @@ class Notifier
         $this->ignoredPhpErrors = $config['ignoredPhpErrors'];
         $this->repeatTimeout    = $config['repeatTimeout'];
         $this->errorsDir        = $cacheDir.'/errors';
+        $this->ignoredIPs       = $config['ignoredIPs'];
 
         if (!is_dir($this->errorsDir)) {
             mkdir($this->errorsDir);
@@ -94,7 +96,7 @@ class Notifier
         $exception = $event->getException();
 
         if ($exception instanceof HttpException) {
-            if (500 === $exception->getStatusCode() || (404 === $exception->getStatusCode() && true === $this->handle404) || (in_array($exception->getStatusCode(), $this->handleHTTPcodes))) {
+            if (!in_array($event->getRequest()->getClientIp(), $this->ignoredIPs) && (500 === $exception->getStatusCode() || (404 === $exception->getStatusCode() && true === $this->handle404) || (in_array($exception->getStatusCode(), $this->handleHTTPcodes)))) {
                 $this->createMailAndSend($exception, $event->getRequest());
             }
         } else {

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ You may control the depth of recursion with a parameter, say foo = array('a'=>ar
 
 Default value is 1. (MAX_DEPTH const)
 
+### How to ignore sending HTTP errors if request comes from given IPs ?
+
+If you want to ignore sending HTTP errors if the request comes from specific IPs, you can now specify the list of ignored IPs.
+
+```yml
+# app/config/config_prod.yml
+elao_error_notifier:
+    ignoredIPs:
+        - "178.63.45.100"
+        - ...
+```
 
 ## Screenshot
 


### PR DESCRIPTION
I have installed the bundle and it works fine.
But the hosting company run some monitoring scripts on the hosted sites.
I receive three 404 error emails every 5 minutes for the following not found urls.
/.svn/format
/CVS/Root
/.git/config

the hosting compnay want to check that no version control configurations exist in the web root.
they do these checks from 2 or 3 ips.
I think we may need this feature for many other reasons.

thanks a lot