### PR TITLE
Lazy load the listener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -91,6 +91,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('ignoredUrlsPattern')
                     ->defaultValue('')
                 ->end()
+                ->booleanNode('lazyLoad')
+                    ->defaultValue(true)
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/ElaoErrorNotifierExtension.php
+++ b/DependencyInjection/ElaoErrorNotifierExtension.php
@@ -39,9 +39,16 @@ class ElaoErrorNotifierExtension extends Extension
             $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__ . '/../Resources/config/')));
             $loader->load('services.xml');
 
+            $definition = false;
+
             if ($config['mailer'] != 'mailer') {
                 $definition = $container->getDefinition('elao.error_notifier.listener');
                 $definition->replaceArgument(0, new Reference($config['mailer']));
+            }
+
+            if ($config['lazyLoad']) {
+                $definition = $definition ?: $container->getDefinition('elao.error_notifier.listener');
+                $definition->setLazy($config['lazyLoad']);
             }
         }
     }


### PR DESCRIPTION
I've been doing some profiling using blackfire.io and the Notifier listener is instantiated on every request whether there's an exception or not. This is adding quite a lot of overhead so I've added an option to [lazy load](http://symfony.com/doc/current/components/dependency_injection/lazy_services.html) the service.
The only disadvantage is that if there is a memory exception then it might not be caught by the service since the memory isn't available to instantiate the service.