### PR TITLE
Show previous exception stack trace

### DIFF
--- a/Resources/views/mail.html.twig
+++ b/Resources/views/mail.html.twig
@@ -343,7 +343,7 @@
                                 {% for position, e in exception.toarray %}
                                     {# see TwigBundle:Exception:traces.html.twig #}
                                     <ol class="traces list_exception" id="traces">
-                                        {% for i, trace in exception.trace %}
+                                        {% for i, trace in e.trace %}
                                             {# see TwigBundle:Exception:trace.html.twig #}
                                             <li>
                                             {% if trace.class is defined %}


### PR DESCRIPTION
This has annoyed me for a while so I thought I'd finally fix it. When specifying a previous exception like
```php
catch(\Exception $previousException)
{
    throw new CustomException($previousException->getMessage(), $previousException->getCode(). $previousException);
}
```
It would show the exception trace for CustomException twice in the email which isn't that helpful. This PR now shows the previous exception trace as well as the wrapped one.