### PR TITLE
Handle php7 \Error in Notifier::createMailAndSend()

### DIFF
--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -302,7 +302,7 @@ class Notifier
     }
 
     /**
-     * @param ErrorException $exception
+     * @param \Throwable     $exception
      * @param Request        $request
      * @param array          $context
      * @param Command        $command
@@ -311,8 +311,19 @@ class Notifier
     public function createMailAndSend($exception, Request $request = null, $context = null, Command $command = null, InputInterface $commandInput = null)
     {
         if (!$exception instanceof FlattenException) {
+            if ($exception instanceof \Error) {
+                $exception = new \ErrorException(
+                    $exception->getMessage(),
+                    $exception->getCode(),
+                    E_ERROR,
+                    $exception->getFile(),
+                    $exception->getLine()
+                );
+            }
+
             $exception = FlattenException::create($exception);
         }
+
         if ($this->repeatTimeout && $this->checkRepeat($exception)) {
             return;
         }


### PR DESCRIPTION
Hi there,

I'm using the bundle in a symfony command which is executed inside a process where exceptions must not be thrown, thus all errors/exceptions are caught and sent by email using the `@elao.error_notifier.listener` service directly like this:

```php
try {
    // do something
} catch (\Throwable $e) {
    $this->errorNotifier->createMailAndSend($e, null, null, $this);
}
```

Things turn bad when `$e` is an instance of `\Error`:

>   [Symfony\Component\Debug\Exception\FatalThrowableError]
>  Type error: Argument 1 passed to Symfony\Component\Debug\Exception\FlattenException::create() must be an instance of Exception, instance of Error given, called in /srv/app/vendor/elao/error-notifier-bundle/Listener/Notifier.php on line 313

So here is a proposal to handle these errors in the `Notifier#createMailAndSend()` method directly. 