### PR TITLE
Allow from naming

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -43,9 +43,17 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')
                     ->end()
                 ->end()
-                ->scalarNode('from')
+                ->arrayNode('from')
+                    ->beforeNormalization()
+                    ->ifString()
+                        ->then(function ($value) {
+                            return array($value);
+                        })
+                    ->end()
                     ->isRequired()
                     ->cannotBeEmpty()
+                    ->prototype('scalar')
+                    ->end()
                 ->end()
                 ->booleanNode('handle404')
                     ->defaultValue(false)


### PR DESCRIPTION
This PR makes `from` an `arrayNode` (just like `to`) to allow naming of the sender address:
```yml
elao_error_notifier:
    from:
        noreply@myvendor.com: "MyVendor Ltd."
```