### PR TITLE
add server to filterRequest to prevent leaking secrets from DotEnv

### DIFF
--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -378,7 +378,7 @@ class Notifier
 
         $replaceWith = '*******';
 
-        foreach (['request', 'query', 'attributes', 'cookies'] as $type) {
+        foreach (['server', 'request', 'query', 'attributes', 'cookies'] as $type) {
             foreach ($request->$type as $key => $value) {
                 // filter key => value parameters by key name
                 if (in_array($key, $this->filteredRequestParams)) {


### PR DESCRIPTION
When you set vars using .env files these leak secrets in the emails!!

We need to filter them out! 