### PR TITLE
error context si deprecated since PHP 7.2.0

### DIFF
--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -215,7 +215,7 @@ class Notifier
      *
      * @throws ErrorException
      */
-    public function handlePhpError($level, $message, $file, $line, $errcontext)
+    public function handlePhpError($level, $message, $file, $line, $errcontext = null)
     {
         // don't catch error with error_repoting is 0
         if (0 === error_reporting() && false === $this->reportSilent) {


### PR DESCRIPTION
fixes https://github.com/Elao/ErrorNotifierBundle/issues/75

Info: https://secure.php.net/manual/en/function.set-error-handler.php