### PR TITLE
From symfony templating to twig

### DIFF
--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig_Environment;
 
 /**
  * Notifier
@@ -34,9 +34,9 @@ class Notifier
     private $mailer;
 
     /**
-     * @var EngineInterface
+     * @var Twig_Environment
      */
-    private $templating;
+    private $twig;
 
     /**
      * @var string
@@ -66,15 +66,15 @@ class Notifier
     /**
      * The constructor
      *
-     * @param Swift_Mailer    $mailer     mailer
-     * @param EngineInterface $templating templating
-     * @param string          $cacheDir   cacheDir
-     * @param array           $config     configure array
+     * @param Swift_Mailer     $mailer     mailer
+     * @param Twig_Environment $twig       twig
+     * @param string           $cacheDir   cacheDir
+     * @param array            $config     configure array
      */
-    public function __construct(Swift_Mailer $mailer, EngineInterface $templating, $cacheDir, $config)
+    public function __construct(Swift_Mailer $mailer, Twig_Environment $twig, $cacheDir, $config)
     {
         $this->mailer                = $mailer;
-        $this->templating            = $templating;
+        $this->twig                  = $twig;
         $this->from                  = $config['from'];
         $this->to                    = $config['to'];
         $this->handle404             = $config['handle404'];
@@ -330,7 +330,7 @@ class Notifier
             return;
         }
 
-        $body = $this->templating->render('ElaoErrorNotifierBundle::mail.html.twig', array(
+        $body = $this->twig->render('ElaoErrorNotifierBundle::mail.html.twig', array(
             'exception'       => $exception,
             'request'         => $request ? $this->filterRequest($request): null,
             'status_code'     => $exception->getCode(),

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,7 +15,7 @@
             <tag name="kernel.event_listener" event="console.exception" method="onConsoleException" priority="0"/>
             <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" priority="0"/>
             <argument type="service" id="mailer" />
-            <argument type="service" id="templating" />
+            <argument type="service" id="twig" />
             <argument>%kernel.cache_dir%</argument>
             <argument>%elao.error_notifier.config%</argument>
         </service>

--- a/Twig/DumpyTwigFilter.php
+++ b/Twig/DumpyTwigFilter.php
@@ -11,6 +11,8 @@ namespace Elao\ErrorNotifierBundle\Twig;
 
 use Elao\ErrorNotifierBundle\Exception\InvokerException;
 use Symfony\Component\Yaml\Dumper as YamlDumper;
+use Twig_Extension;
+use Twig_SimpleFilter;
 
 /**
  * Extends Twig with
@@ -36,7 +38,7 @@ use Symfony\Component\Yaml\Dumper as YamlDumper;
  *
  * @author Goutte
  */
-class DumpyTwigFilter extends \Twig_Extension
+class DumpyTwigFilter extends Twig_Extension
 {
     /** @const INLINE : default value for the inline parameter of the YAML dumper aka the expanding-level */
     const INLINE = 3;
@@ -51,9 +53,9 @@ class DumpyTwigFilter extends \Twig_Extension
         $optionsForRaw = array('is_safe' => array('all')); // allows raw dumping (otherwise <pre> is encoded)
 
         return array(
-            'pre'   => new \Twig_SimpleFilter('pre', array($this, 'pre'), $optionsForRaw),
-            'dump'  => new \Twig_SimpleFilter('dump', array($this, 'preDump'), $optionsForRaw),
-            'dumpy' => new \Twig_SimpleFilter('dumpy', array($this, 'preYamlDump'), $optionsForRaw),
+            'pre'   => new Twig_SimpleFilter('pre', array($this, 'pre'), $optionsForRaw),
+            'dump'  => new Twig_SimpleFilter('dump', array($this, 'preDump'), $optionsForRaw),
+            'dumpy' => new Twig_SimpleFilter('dumpy', array($this, 'preYamlDump'), $optionsForRaw),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php":                      ">=5.3.2",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/console":          "~2.3|~3.0",
+        "symfony/twig-bundle":      "~2.3|~3.0",
         "swiftmailer/swiftmailer":  "~5.0|~6.0"
     },
 


### PR DESCRIPTION
Symfony templating service will be deprecated [soon or later](https://github.com/symfony/symfony/pull/21035), and has already be [removed from standard edition](https://github.com/symfony/symfony-standard/pull/1110)

`Twig_Environment` offers the same `render` method, so this is just a matter of dependency switch.