### PR TITLE
Use namespaced twig paths

### DIFF
--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -330,7 +330,7 @@ class Notifier
             return;
         }
 
-        $body = $this->twig->render('ElaoErrorNotifierBundle::mail.html.twig', array(
+        $body = $this->twig->render('@ElaoErrorNotifier/mail.html.twig', array(
             'exception'       => $exception,
             'request'         => $request ? $this->filterRequest($request): null,
             'status_code'     => $exception->getCode(),

--- a/Resources/views/mail.html.twig
+++ b/Resources/views/mail.html.twig
@@ -341,10 +341,10 @@
                             <div class="block">
                                 <h4>Stack Trace</h4>
                                 {% for position, e in exception.toarray %}
-                                    {# see TwigBundle:Exception:traces.html.twig #}
+                                    {# see @Twig/Exception/traces.html.twig #}
                                     <ol class="traces list_exception" id="traces">
                                         {% for i, trace in e.trace %}
-                                            {# see TwigBundle:Exception:trace.html.twig #}
+                                            {# see @Twig/Exception/trace.html.twig #}
                                             <li>
                                             {% if trace.class is defined %}
                                                 at
@@ -480,7 +480,7 @@
                             <h4>Request GET Parameters</h4>
 
                             {% if request.query.all|length %}
-                                {% include 'ElaoErrorNotifierBundle::_bag.html.twig' with { 'bag': request.query } only %}
+                                {% include '@ElaoErrorNotifier/_bag.html.twig' with { 'bag': request.query } only %}
                             {% else %}
                                 <p>
                                     <em>No GET parameters</em>
@@ -503,7 +503,7 @@
                             <h4>Request POST Parameters</h4>
 
                             {% if request.request.all|length %}
-                                {% include 'ElaoErrorNotifierBundle::_bag.html.twig' with { 'bag': request.request } only %}
+                                {% include '@ElaoErrorNotifier/_bag.html.twig' with { 'bag': request.request } only %}
                             {% else %}
                                 <p>
                                     <em>No POST parameters</em>
@@ -526,7 +526,7 @@
                             <h4>Request Attributes</h4>
 
                             {% if request.attributes.all|length %}
-                                {% include 'ElaoErrorNotifierBundle::_bag.html.twig' with { 'bag': request.attributes } only %}
+                                {% include '@ElaoErrorNotifier/_bag.html.twig' with { 'bag': request.attributes } only %}
                             {% else %}
                                 <p>
                                     <em>No Request Attributes</em>
@@ -549,7 +549,7 @@
                             <h4>Request Cookies</h4>
 
                             {% if request.cookies.all|length %}
-                                {% include 'ElaoErrorNotifierBundle::_bag.html.twig' with { 'bag': request.cookies } only %}
+                                {% include '@ElaoErrorNotifier/_bag.html.twig' with { 'bag': request.cookies } only %}
                             {% else %}
                                 <p>
                                     <em>No Request Cookies</em>
@@ -570,7 +570,7 @@
                     <tr>
                         <td>
                             <h4>Request Headers</h4>
-                            {% include 'ElaoErrorNotifierBundle::_bag.html.twig' with { 'bag': request.headers } only %}
+                            {% include '@ElaoErrorNotifier/_bag.html.twig' with { 'bag': request.headers } only %}
                         </td>
                     </tr>
                 </table>
@@ -586,7 +586,7 @@
                     <tr>
                         <td>
                             <h4>Request Server Parameters </h4>
-                            {% include 'ElaoErrorNotifierBundle::_bag.html.twig' with { 'bag': request.server } only %}
+                            {% include '@ElaoErrorNotifier/_bag.html.twig' with { 'bag': request.server } only %}
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
Available since TwigBundle version 2.2 (See: https://symfony.com/doc/2.2/cookbook/templating/namespaced_paths.html)

This allows symfony projects not to use framework templating service anymore \o/