### PR TITLE
fix(readme): fix class reference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Sometimes, you want the bundle not to send email for errors raised by a given cl
 # app/config/config_prod.yml
 elao_error_notifier:
     ignoredClasses:
-        - "Guzzle\Http\Exception\ServerErrorResponseException"
+        - "Guzzle\\Http\\Exception\\ServerErrorResponseException"
         - ...
 ```
 


### PR DESCRIPTION
Escape the backslashes in the `ignoreClasses` example. Otherwise it's invalid yml format.