### PR TITLE
[Symfony4] Replaced ConsoleExceptionEvent with ConsoleError

### DIFF
--- a/DependencyInjection/ElaoErrorNotifierExtension.php
+++ b/DependencyInjection/ElaoErrorNotifierExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
+
 /**
  * ElaoErrorNotifier Extension
  */
@@ -39,9 +40,16 @@ class ElaoErrorNotifierExtension extends Extension
             $loader = new XmlFileLoader($container, new FileLocator(array(__DIR__ . '/../Resources/config/')));
             $loader->load('services.xml');
 
+            $definition = $container->getDefinition('elao.error_notifier.listener');
+            
             if ($config['mailer'] != 'mailer') {
-                $definition = $container->getDefinition('elao.error_notifier.listener');
                 $definition->replaceArgument(0, new Reference($config['mailer']));
+            }
+            
+            if (true === class_exists('Symfony\Component\Console\Event\ConsoleErrorEvent')) {
+                $definition->addTag('kernel.event_listener', ['event' => 'console.error', 'method' => 'onConsoleError', 'priority' => 0]);
+            } else {
+                $definition->addTag('kernel.event_listener', ['event' => 'console.exception', 'method' => 'onConsoleException', 'priority' => 0]);
             }
         }
     }

--- a/Listener/Notifier.php
+++ b/Listener/Notifier.php
@@ -14,6 +14,7 @@ use Swift_Mailer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
@@ -137,16 +138,33 @@ class Notifier
             }
         }
     }
-
+    
     /**
-     * Handle the event
+     * Handle the console exceptions (Symfony 2.3-3.4)
      *
      * @param ConsoleExceptionEvent $event event
      */
     public function onConsoleException(ConsoleExceptionEvent $event)
     {
-        $exception = $event->getException();
+        $this->handleConsoleException($event->getException());
+    }
 
+    /**
+     * Handle the console errors (Symfony 4+)
+     *
+     * @param ConsoleErrorEvent $event event
+     */
+    public function onConsoleError(ConsoleErrorEvent $event)
+    {
+        $this->handleConsoleException($event->getError());
+    }
+
+    /**
+     * Common handling logic for console exceptions
+     * @param \Throwable $exception
+     */
+    private function handleConsoleException(\Throwable $exception)
+    {
         $sendMail = !in_array(get_class($exception), $this->ignoredClasses);
 
         if ($sendMail === true) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,6 @@
         <service id="elao.error_notifier.listener" class="%elao.error_notifier.listener.class%">
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="0"/>
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="0"/>
-            <tag name="kernel.event_listener" event="console.exception" method="onConsoleException" priority="0"/>
             <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" priority="0"/>
             <argument type="service" id="mailer" />
             <argument type="service" id="twig" />


### PR DESCRIPTION
Per https://github.com/symfony/symfony/blob/master/UPGRADE-4.0.md#console the ConsoleExceptionEvent is removed in Symfony 4+ and completely replace with the ConsoleError event.  The ConsoleError event was introduced in Console 3.3 so I've bumped that dependency requirement in the composer file.

**This is a BC break as below Symfony 3.3 will no longer work with this version so please keep that in mind at release.**